### PR TITLE
symlink mpi so we can just do -lmpi and find it in a default search path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,23 +7,20 @@ ENV TMPDIR=/tmp
 ENV MODULEPATH=/etc/scl/modulefiles:/etc/scl/modulefiles:/usr/share/Modules/modulefiles:/etc/modulefiles:/usr/share/modulefiles
 
 
-RUN dnf install -y git openssl-devel && \
-    cd $HOME && git clone https://github.com/rui314/mold.git -b v1.0.1 && \
-    cd mold && make -j && make install && cd .. && rm -rf mold
-
-RUN eval `modulecmd bash load mpi/openmpi-x86_64` && \
+RUN dnf install -y git openssl-devel && cd $HOME && \
+    git clone https://github.com/rui314/mold.git -b v1.0.1 && \
+   (cd mold && make -j && make install) && rm -rf mold && \
+    eval `modulecmd bash load mpi/openmpi-x86_64` && \
     git clone https://github.com/llnl/samrai -b develop  samrai --recursive --depth 10 && \
-    cd samrai && mkdir build && cd build && \
+   (cd samrai && mkdir build && cd build && \
     cmake .. \
       -DENABLE_OPENMP=OFF -DENABLE_TESTS=OFF -DENABLE_SAMRAI_TESTS=OFF \
       -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo && \
-    make -j && make install && cd ../.. && rm -rf samrai
-
-
+    make -j && make install) && rm -rf samrai && \
+    ln -s /usr/lib64/openmpi/lib/libmpi_cxx.so /usr/local/lib64 && \
+    ln -s /usr/lib64/openmpi/lib/libmpi_usempif08.so /usr/local/lib64 && \
+    ln -s /usr/lib64/openmpi/lib/libmpi_usempi_ignore_tkr.so /usr/local/lib64 && \
+    ln -s /usr/lib64/openmpi/lib/libmpi_mpifh.so /usr/local/lib64 && \
+    ln -s /usr/lib64/openmpi/lib/libmpi.so /usr/local/lib64
 # SAMRAI doesn't find MPI for us anymore properly for some reason
-RUN ln -s /usr/lib64/openmpi/lib/libmpi_cxx.so /usr/local/lib64
-RUN ln -s /usr/lib64/openmpi/lib/libmpi_usempif08.so /usr/local/lib64
-RUN ln -s /usr/lib64/openmpi/lib/libmpi_usempi_ignore_tkr.so /usr/local/lib64
-RUN ln -s /usr/lib64/openmpi/lib/libmpi_mpifh.so /usr/local/lib64
-RUN ln -s /usr/lib64/openmpi/lib/libmpi.so /usr/local/lib64

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,21 +6,6 @@ ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 ENV TMPDIR=/tmp
 ENV MODULEPATH=/etc/scl/modulefiles:/etc/scl/modulefiles:/usr/share/Modules/modulefiles:/etc/modulefiles:/usr/share/modulefiles
 
-
-RUN dnf install -y git openssl-devel && cd $HOME && \
-    git clone https://github.com/rui314/mold.git -b v1.0.1 && \
-   (cd mold && make -j && make install) && rm -rf mold && \
-    eval `modulecmd bash load mpi/openmpi-x86_64` && \
-    git clone https://github.com/llnl/samrai -b develop  samrai --recursive --depth 10 && \
-   (cd samrai && mkdir build && cd build && \
-    cmake .. \
-      -DENABLE_OPENMP=OFF -DENABLE_TESTS=OFF -DENABLE_SAMRAI_TESTS=OFF \
-      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true \
-      -DCMAKE_BUILD_TYPE=RelWithDebInfo && \
-    make -j && make install) && rm -rf samrai && \
-    ln -s /usr/lib64/openmpi/lib/libmpi_cxx.so /usr/local/lib64 && \
-    ln -s /usr/lib64/openmpi/lib/libmpi_usempif08.so /usr/local/lib64 && \
-    ln -s /usr/lib64/openmpi/lib/libmpi_usempi_ignore_tkr.so /usr/local/lib64 && \
-    ln -s /usr/lib64/openmpi/lib/libmpi_mpifh.so /usr/local/lib64 && \
-    ln -s /usr/lib64/openmpi/lib/libmpi.so /usr/local/lib64
-# SAMRAI doesn't find MPI for us anymore properly for some reason
+WORKDIR /root
+COPY run.sh /root
+RUN chmod +x run.sh && ./run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,10 @@ RUN eval `modulecmd bash load mpi/openmpi-x86_64` && \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo && \
     make -j && make install && cd ../.. && rm -rf samrai
 
+
+# SAMRAI doesn't find MPI for us anymore properly for some reason
+RUN ln -s /usr/lib64/openmpi/lib/libmpi_cxx.so /usr/local/lib64
+RUN ln -s /usr/lib64/openmpi/lib/libmpi_usempif08.so /usr/local/lib64
+RUN ln -s /usr/lib64/openmpi/lib/libmpi_usempi_ignore_tkr.so /usr/local/lib64
+RUN ln -s /usr/lib64/openmpi/lib/libmpi_mpifh.so /usr/local/lib64
+RUN ln -s /usr/lib64/openmpi/lib/libmpi.so /usr/local/lib64

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,27 @@
+dnf install -y git openssl-devel
+
+cd $HOME
+
+git clone https://github.com/rui314/mold.git -b v1.0.1
+(cd mold && make -j && make install)
+rm -rf mold
+
+eval `modulecmd bash load mpi/openmpi-x86_64`
+
+git clone https://github.com/llnl/samrai -b develop samrai --recursive --depth 10
+(
+  cd samrai && mkdir build && cd build
+  cmake .. \
+  -DENABLE_OPENMP=OFF -DENABLE_TESTS=OFF -DENABLE_SAMRAI_TESTS=OFF \
+  -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  make -j && make install
+)
+rm -rf samrai
+
+# SAMRAI doesn't find MPI for us anymore properly for some reason
+ln -s /usr/lib64/openmpi/lib/libmpi_cxx.so /usr/local/lib64
+ln -s /usr/lib64/openmpi/lib/libmpi_usempif08.so /usr/local/lib64
+ln -s /usr/lib64/openmpi/lib/libmpi_usempi_ignore_tkr.so /usr/local/lib64
+ln -s /usr/lib64/openmpi/lib/libmpi_mpifh.so /usr/local/lib64
+ln -s /usr/lib64/openmpi/lib/libmpi.so /usr/local/lib64


### PR DESCRIPTION
this is to get around https://github.com/LLNL/SAMRAI/issues/222